### PR TITLE
Issue Bugfix - #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ tpa:
 ## Permissions
 Do these even work atm?
 
-| Admin Permission           | Description                              |
-|----------------------------|------------------------------------------|
-| `systemhomes.admin.*`      | Grants access to all admin perms.        |
-| `systemhomes.admin.reload` | Grants access to reload.                 |
-| `systemhomes.admin.warp`   | Grants access to set and delete warp.    |
-| `systemhomes.admin.pwarp`  | Grants access to delete all playerwarps. |
+| Admin Permission           | Description                                         |
+|----------------------------|-----------------------------------------------------|
+| `systemhomes.admin.*`      | Grants access to all admin perms.                   |
+| `systemhomes.admin.reload` | Grants access to reload.                            |
+| `systemhomes.admin.warp`   | Grants access to set and delete warp.               |
+| `systemhomes.admin.pwarp`  | Grants access to delete and modify all PlayerWarps. |
 
 | Player Permissions (default) | Description                                           |
 |------------------------------|-------------------------------------------------------|

--- a/src/main/java/moe/sebiann/system/commands/PlayerWarpCommands.java
+++ b/src/main/java/moe/sebiann/system/commands/PlayerWarpCommands.java
@@ -43,6 +43,13 @@ public class PlayerWarpCommands extends BaseCommand {
         );
 
         if(PlayerWarp.containsPlayerWarp(warpPath)) {
+
+            PlayerWarp pwarp = PlayerWarp.getPlayerWarp(args[0]);
+            if(!pwarp.getOwningPlayer().equals(player.getUniqueId()) || !player.hasPermission("systemhomes.admin.pwarp")) {
+                player.sendMessage(Component.text("You may not modify someone else's PlayerWarp!").color(TextColor.fromHexString("#FF5555")));
+                return;
+            }
+
             if(pendingOverwrittenConfirmations.contains(args[0])) {
                 try{
                     warp.uploadPlayerWarp();


### PR DESCRIPTION
Players are now unable to modify playerwarps unless they have the permission `systemhomes.admin.pwarp`

Bugfix: #7 
Playtested: No (I did not have luckperms installed, lazy me I know)